### PR TITLE
Add fox hunt CW beacon feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ ENABLE_REDUCE_LOW_MID_TX_POWER?= 0
 ENABLE_BYP_RAW_DEMODULATORS   ?= 0
 ENABLE_BLMIN_TMP_OFF          ?= 0
 ENABLE_SCAN_RANGES            ?= 1
+ENABLE_FOXHUNT_TX             ?= 1
 
 # ---- DEBUGGING ----
 ENABLE_AM_FIX_SHOW_DATA       ?= 0
@@ -117,10 +118,13 @@ OBJS += app/chFrScanner.o
 OBJS += app/common.o
 OBJS += app/dtmf.o
 ifeq ($(ENABLE_FLASHLIGHT),1)
-	OBJS += app/flashlight.o
+        OBJS += app/flashlight.o
 endif
 ifeq ($(ENABLE_FMRADIO),1)
-	OBJS += app/fm.o
+        OBJS += app/fm.o
+endif
+ifeq ($(ENABLE_FOXHUNT_TX),1)
+        OBJS += app/fox.o
 endif
 OBJS += app/generic.o
 OBJS += app/main.o
@@ -360,10 +364,13 @@ ifeq ($(ENABLE_BLMIN_TMP_OFF),1)
 	CFLAGS  += -DENABLE_BLMIN_TMP_OFF
 endif
 ifeq ($(ENABLE_SCAN_RANGES),1)
-	CFLAGS  += -DENABLE_SCAN_RANGES
+        CFLAGS  += -DENABLE_SCAN_RANGES
+endif
+ifeq ($(ENABLE_FOXHUNT_TX),1)
+        CFLAGS  += -DENABLE_FOXHUNT_TX
 endif
 ifeq ($(ENABLE_DTMF_CALLING),1)
-	CFLAGS  += -DENABLE_DTMF_CALLING
+        CFLAGS  += -DENABLE_DTMF_CALLING
 endif
 ifeq ($(ENABLE_AGC_SHOW_DATA),1)
 	CFLAGS  += -DENABLE_AGC_SHOW_DATA

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ You'll find the options at the top of "Makefile" ('0' = disable, '1' = enable) .
 | ENABLE_BYP_RAW_DEMODULATORS | additional BYP (bypass?) and RAW demodulation options, proved not to be very useful, but it is there if you want to experiment |
 | ENABLE_BLMIN_TMP_OFF | additional function for configurable buttons that toggles `BLMin` on and off wihout saving it to the EEPROM |
 | ENABLE_SCAN_RANGES | scan range mode for frequency scanning, see wiki for instructions (radio operation -> frequency scanning) |
+| ENABLE_FOXHUNT_TX | enable the built in fox-hunt CW beacon |
 |🧰 **DEBUGGING** ||
 | ENABLE_AM_FIX_SHOW_DATA| displays settings used by  AM-fix when AM transmission is received |
 | ENABLE_AGC_SHOW_DATA | displays AGC settings |
@@ -214,6 +215,10 @@ Many thanks to various people on Telegram for putting up with me during this eff
 
 [ludwich66 - Quansheng UV-K5 Wiki](https://github.com/ludwich66/Quansheng_UV-K5_Wiki/wiki)<br>
 [amnemonic - tools and sources of information](https://github.com/amnemonic/Quansheng_UV-K5_Firmware)
+
+## Fox hunt transmitter
+
+Enable `ENABLE_FOXHUNT_TX` in the Makefile to build a small CW beacon. New menu entries allow enabling the beacon, adjusting WPM and interval and editing the transmitted text. Selecting `FoxFnd` sends "FOX FOUND" once.
 
 ## License
 

--- a/app/app.c
+++ b/app/app.c
@@ -61,6 +61,9 @@
 #include "misc.h"
 #include "radio.h"
 #include "settings.h"
+#ifdef ENABLE_FOXHUNT_TX
+#include "app/fox.h"
+#endif
 
 #if defined(ENABLE_OVERLAY)
 	#include "sram-overlay.h"
@@ -1453,7 +1456,10 @@ void APP_TimeSlice500ms(void)
 
 	BATTERY_TimeSlice500ms();
 	SCANNER_TimeSlice500ms();
-	UI_MAIN_TimeSlice500ms();
+        UI_MAIN_TimeSlice500ms();
+#ifdef ENABLE_FOXHUNT_TX
+        FOX_TimeSlice500ms();
+#endif
 
 #ifdef ENABLE_DTMF_CALLING
 	if (gCurrentFunction != FUNCTION_TRANSMIT) {

--- a/app/fox.c
+++ b/app/fox.c
@@ -1,0 +1,104 @@
+#ifdef ENABLE_FOXHUNT_TX
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "app/fox.h"
+#include "functions.h"
+#include "settings.h"
+#include "misc.h"
+#include "driver/bk4819.h"
+#include "audio.h"
+
+volatile uint16_t gFoxCountdown_500ms;
+bool gFoxFoundMode;
+
+static const char *morse_table[36] = {
+    ".-", "-...", "-.-.", "-..", ".", "..-.", "--.", "....", "..", ".---", "-.-", ".-..", "--", "-.", "---", ".--.", "--.-", ".-.", "...", "-", "..-", "...-", ".--", "-..-", "-.--", "--..", // A-Z
+    "-----", ".----", "..---", "...--", "....-", ".....", "-....", "--...", "---..", "----." // 0-9
+};
+
+static const char *get_morse(char c)
+{
+    if (c >= 'A' && c <= 'Z')
+        return morse_table[c - 'A'];
+    if (c >= 'a' && c <= 'z')
+        return morse_table[c - 'a'];
+    if (c >= '0' && c <= '9')
+        return morse_table[26 + c - '0'];
+    return "";
+}
+
+static void play_unit(uint16_t ms)
+{
+    BK4819_PlaySingleTone(800, ms, 0, false);
+    SYSTEM_DelayMs(ms);
+    BK4819_EnterTxMute();
+    SYSTEM_DelayMs(ms);
+}
+
+static void send_morse(const char *msg, uint8_t wpm)
+{
+    if (wpm == 0)
+        wpm = 10;
+    uint16_t unit = 1200 / wpm;
+
+    FUNCTION_Select(FUNCTION_TRANSMIT);
+    SYSTEM_DelayMs(20);
+
+    for (const char *p = msg; *p; p++) {
+        if (*p == ' ') {
+            SYSTEM_DelayMs(unit * 7);
+            continue;
+        }
+        const char *code = get_morse(*p);
+        for (const char *s = code; *s; s++) {
+            if (*s == '-')
+                play_unit(unit * 3);
+            else
+                play_unit(unit);
+        }
+        SYSTEM_DelayMs(unit * 3);
+    }
+
+    APP_EndTransmission();
+    FUNCTION_Select(FUNCTION_FOREGROUND);
+}
+
+void FOX_Init(void)
+{
+    gFoxCountdown_500ms = 0;
+    gFoxFoundMode = false;
+}
+
+void FOX_TimeSlice500ms(void)
+{
+    if (gFoxFoundMode) {
+        send_morse("FOX FOUND", gEeprom.FOX.wpm);
+        gFoxFoundMode = false;
+        gFoxCountdown_500ms = gEeprom.FOX.interval_min * 2;
+        return;
+    }
+
+    if (!gEeprom.FOX.enabled)
+        return;
+
+    if (gFoxCountdown_500ms > 0) {
+        gFoxCountdown_500ms--;
+        return;
+    }
+
+    send_morse(gEeprom.FOX.message, gEeprom.FOX.wpm);
+    uint16_t interval = gEeprom.FOX.interval_min;
+    if (gEeprom.FOX.random && gEeprom.FOX.interval_max > gEeprom.FOX.interval_min) {
+        interval += rand() % (gEeprom.FOX.interval_max - gEeprom.FOX.interval_min + 1);
+    }
+    gFoxCountdown_500ms = interval * 2;
+}
+
+void FOX_StartFound(void)
+{
+    gFoxFoundMode = true;
+}
+
+#endif

--- a/app/fox.h
+++ b/app/fox.h
@@ -1,0 +1,14 @@
+#ifndef APP_FOX_H
+#define APP_FOX_H
+
+#ifdef ENABLE_FOXHUNT_TX
+#include <stdint.h>
+#include <stdbool.h>
+
+void FOX_Init(void);
+void FOX_TimeSlice500ms(void);
+void FOX_StartFound(void);
+
+#endif
+
+#endif // APP_FOX_H

--- a/main.c
+++ b/main.c
@@ -28,6 +28,9 @@
 #include "radio.h"
 #include "settings.h"
 #include "version.h"
+#ifdef ENABLE_FOXHUNT_TX
+#include "app/fox.h"
+#endif
 
 #include "app/app.h"
 #include "app/dtmf.h"
@@ -94,7 +97,10 @@ void Main(void)
 
 	SETTINGS_InitEEPROM();
 	SETTINGS_WriteBuildOptions();
-	SETTINGS_LoadCalibration();
+        SETTINGS_LoadCalibration();
+#ifdef ENABLE_FOXHUNT_TX
+        FOX_Init();
+#endif
 
 	RADIO_ConfigureChannel(0, VFO_CONFIGURE_RELOAD);
 	RADIO_ConfigureChannel(1, VFO_CONFIGURE_RELOAD);

--- a/misc.c
+++ b/misc.c
@@ -131,6 +131,10 @@ volatile bool     gNextTimeslice_500ms;
 
 volatile uint16_t gTxTimerCountdown_500ms;
 volatile bool     gTxTimeoutReached;
+#ifdef ENABLE_FOXHUNT_TX
+volatile uint16_t gFoxCountdown_500ms;
+bool              gFoxFoundMode;
+#endif
 
 volatile uint16_t gTailToneEliminationCountdown_10ms;
 

--- a/misc.h
+++ b/misc.h
@@ -204,6 +204,10 @@ extern volatile bool         gNextTimeslice_500ms;
 
 extern volatile uint16_t     gTxTimerCountdown_500ms;
 extern volatile bool         gTxTimeoutReached;
+#ifdef ENABLE_FOXHUNT_TX
+extern volatile uint16_t     gFoxCountdown_500ms;
+extern bool                  gFoxFoundMode;
+#endif
 
 extern volatile uint16_t     gTailToneEliminationCountdown_10ms;
 

--- a/scheduler.c
+++ b/scheduler.c
@@ -56,8 +56,11 @@ void SystickHandler(void)
 	if ((gGlobalSysTickCounter % 50) == 0) {
 		gNextTimeslice_500ms = true;
 		
-		DECREMENT_AND_TRIGGER(gTxTimerCountdown_500ms, gTxTimeoutReached);
-		DECREMENT(gSerialConfigCountDown_500ms);
+                DECREMENT_AND_TRIGGER(gTxTimerCountdown_500ms, gTxTimeoutReached);
+#ifdef ENABLE_FOXHUNT_TX
+                DECREMENT(gFoxCountdown_500ms);
+#endif
+                DECREMENT(gSerialConfigCountDown_500ms);
 	}
 
 	if ((gGlobalSysTickCounter & 3) == 0)

--- a/settings.h
+++ b/settings.h
@@ -250,7 +250,18 @@ typedef struct {
 	BATTERY_Type_t		  BATTERY_TYPE;
 #ifdef ENABLE_RSSI_BAR
 	uint8_t               S0_LEVEL;
-	uint8_t               S9_LEVEL;
+        uint8_t               S9_LEVEL;
+#endif
+#ifdef ENABLE_FOXHUNT_TX
+        struct {
+                uint8_t  enabled;
+                uint8_t  random;
+                uint8_t  wpm;
+                uint8_t  reserved;
+                uint16_t interval_min;
+                uint16_t interval_max;
+                char     message[24];
+        } FOX;
 #endif
 } EEPROM_Config_t;
 

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -136,8 +136,17 @@ const t_menu_item MenuList[] =
 	{"FrCali", VOICE_ID_INVALID,                       MENU_F_CALI        }, // reference xtal calibration
 #endif
 	{"BatCal", VOICE_ID_INVALID,                       MENU_BATCAL        }, // battery voltage calibration
-	{"BatTyp", VOICE_ID_INVALID,                       MENU_BATTYP        }, // battery type 1600/2200mAh
-	{"Reset",  VOICE_ID_INITIALISATION,                MENU_RESET         }, // might be better to move this to the hidden menu items ?
+        {"BatTyp", VOICE_ID_INVALID,                       MENU_BATTYP        }, // battery type 1600/2200mAh
+#ifdef ENABLE_FOXHUNT_TX
+        {"FoxTx",  VOICE_ID_INVALID,                       MENU_FOX_EN        },
+        {"FoxWPM", VOICE_ID_INVALID,                       MENU_FOX_WPM       },
+        {"IntMin", VOICE_ID_INVALID,                       MENU_FOX_INTMIN    },
+        {"IntMax", VOICE_ID_INVALID,                       MENU_FOX_INTMAX    },
+        {"RndInt", VOICE_ID_INVALID,                       MENU_FOX_RANDOM    },
+        {"FoxMsg", VOICE_ID_INVALID,                       MENU_FOX_MSG       },
+        {"FoxFnd", VOICE_ID_INVALID,                       MENU_FOX_FOUND     },
+#endif
+        {"Reset",  VOICE_ID_INITIALISATION,                MENU_RESET         }, // might be better to move this to the hidden menu items ?
 
 	{"",       VOICE_ID_INVALID,                       0xff               }  // end of list - DO NOT delete or move this this
 };
@@ -830,13 +839,37 @@ void UI_DisplayMenu(void)
 			break;
 		}
 
-		case MENU_BATTYP:
-			strcpy(String, gSubMenu_BATTYP[gSubMenuSelection]);
-			break;
+                case MENU_BATTYP:
+                        strcpy(String, gSubMenu_BATTYP[gSubMenuSelection]);
+                        break;
+#ifdef ENABLE_FOXHUNT_TX
+                case MENU_FOX_EN:
+                        strcpy(String, gSubMenu_OFF_ON[gSubMenuSelection]);
+                        break;
+                case MENU_FOX_RANDOM:
+                        strcpy(String, gSubMenu_OFF_ON[gSubMenuSelection]);
+                        break;
+                case MENU_FOX_WPM:
+                        sprintf(String, "%u WPM", gSubMenuSelection);
+                        break;
+                case MENU_FOX_INTMIN:
+                case MENU_FOX_INTMAX:
+                        sprintf(String, "%us", gSubMenuSelection);
+                        break;
+                case MENU_FOX_MSG:
+                        if(edit_index >= 0)
+                                strcpy(String, edit);
+                        else
+                                strcpy(String, gEeprom.FOX.message);
+                        break;
+                case MENU_FOX_FOUND:
+                        strcpy(String, "PLAY");
+                        break;
+#endif
 
-		case MENU_F1SHRT:
-		case MENU_F1LONG:
-		case MENU_F2SHRT:
+                case MENU_F1SHRT:
+                case MENU_F1LONG:
+                case MENU_F2SHRT:
 		case MENU_F2LONG:
 		case MENU_MLONG:
 			strcpy(String, gSubMenu_SIDEFUNCTIONS[gSubMenuSelection].name);

--- a/ui/menu.h
+++ b/ui/menu.h
@@ -122,8 +122,17 @@ enum
 	MENU_F1LONG,
 	MENU_F2SHRT,
 	MENU_F2LONG,
-	MENU_MLONG,
-	MENU_BATTYP
+        MENU_MLONG,
+        MENU_BATTYP
+#ifdef ENABLE_FOXHUNT_TX
+        ,MENU_FOX_EN
+        ,MENU_FOX_WPM
+        ,MENU_FOX_INTMIN
+        ,MENU_FOX_INTMAX
+        ,MENU_FOX_RANDOM
+        ,MENU_FOX_MSG
+        ,MENU_FOX_FOUND
+#endif
 };
 
 extern const uint8_t FIRST_HIDDEN_MENU_ITEM;


### PR DESCRIPTION
## Summary
- introduce ENABLE_FOXHUNT_TX option
- implement fox hunt CW beacon transmitter
- add menu entries to configure beacon
- persist beacon settings in EEPROM
- document new feature