### PR TITLE
Add fox beacon frequency and tone options

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Many thanks to various people on Telegram for putting up with me during this eff
 
 ## Fox hunt transmitter
 
-Enable `ENABLE_FOXHUNT_TX` in the Makefile to build a small CW beacon. New menu entries allow enabling the beacon, adjusting WPM and interval and editing the transmitted text. Selecting `FoxFnd` sends "FOX FOUND" once.
+Enable `ENABLE_FOXHUNT_TX` in the Makefile to build a small CW beacon. New menu entries allow enabling the beacon, adjusting WPM and interval, setting CW pitch, transmit frequency and optional CTCSS tone, and editing the transmitted text. Selecting `FoxFnd` sends "FOX FOUND" once.
 
 ## License
 

--- a/settings.c
+++ b/settings.c
@@ -284,9 +284,12 @@ void SETTINGS_InitEEPROM(void)
                         uint8_t  enabled;
                         uint8_t  random;
                         uint8_t  wpm;
-                        uint8_t  reserved;
+                        uint8_t  power;
                         uint16_t interval_min;
                         uint16_t interval_max;
+                        uint32_t frequency;
+                        uint16_t pitch_hz;
+                        uint16_t ctcss_hz;
                         char     message[24];
                 } __attribute__((packed)) foxCfg;
                 EEPROM_ReadBuffer(0x1FD0, &foxCfg, sizeof(foxCfg));
@@ -294,7 +297,11 @@ void SETTINGS_InitEEPROM(void)
                 if (gEeprom.FOX.wpm == 0) gEeprom.FOX.wpm = 10;
                 if (gEeprom.FOX.interval_min == 0) gEeprom.FOX.interval_min = 60;
                 if (gEeprom.FOX.interval_max < gEeprom.FOX.interval_min) gEeprom.FOX.interval_max = gEeprom.FOX.interval_min;
+                if (gEeprom.FOX.frequency == 0) gEeprom.FOX.frequency = SETTINGS_FetchChannelFrequency(0);
+                if (gEeprom.FOX.power > 2) gEeprom.FOX.power = 1;
                 if (gEeprom.FOX.message[0] == '\0') strcpy(gEeprom.FOX.message, "FOX");
+                if (gEeprom.FOX.pitch_hz == 0) gEeprom.FOX.pitch_hz = 800;
+                if (gEeprom.FOX.ctcss_hz > 2541) gEeprom.FOX.ctcss_hz = 0;
         }
 #endif
 }
@@ -619,9 +626,12 @@ void SETTINGS_SaveSettings(void)
                         uint8_t  enabled;
                         uint8_t  random;
                         uint8_t  wpm;
-                        uint8_t  reserved;
+                        uint8_t  power;
                         uint16_t interval_min;
                         uint16_t interval_max;
+                        uint32_t frequency;
+                        uint16_t pitch_hz;
+                        uint16_t ctcss_hz;
                         char     message[24];
                 } __attribute__((packed)) foxCfg;
                 memcpy(&foxCfg, &gEeprom.FOX, sizeof(foxCfg));

--- a/settings.h
+++ b/settings.h
@@ -257,9 +257,12 @@ typedef struct {
                 uint8_t  enabled;
                 uint8_t  random;
                 uint8_t  wpm;
-                uint8_t  reserved;
+                uint8_t  power;
                 uint16_t interval_min;
                 uint16_t interval_max;
+                uint32_t frequency;
+                uint16_t pitch_hz;
+                uint16_t ctcss_hz;
                 char     message[24];
         } FOX;
 #endif

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -144,6 +144,9 @@ const t_menu_item MenuList[] =
         {"IntMax", VOICE_ID_INVALID,                       MENU_FOX_INTMAX    },
         {"RndInt", VOICE_ID_INVALID,                       MENU_FOX_RANDOM    },
         {"FoxMsg", VOICE_ID_INVALID,                       MENU_FOX_MSG       },
+        {"FxPtch", VOICE_ID_INVALID,                       MENU_FOX_PITCH     },
+        {"FxFreq", VOICE_ID_INVALID,                       MENU_FOX_FREQ      },
+        {"FxTone", VOICE_ID_INVALID,                       MENU_FOX_TONE      },
         {"FoxFnd", VOICE_ID_INVALID,                       MENU_FOX_FOUND     },
 #endif
         {"Reset",  VOICE_ID_INITIALISATION,                MENU_RESET         }, // might be better to move this to the hidden menu items ?
@@ -861,6 +864,18 @@ void UI_DisplayMenu(void)
                                 strcpy(String, edit);
                         else
                                 strcpy(String, gEeprom.FOX.message);
+                        break;
+                case MENU_FOX_PITCH:
+                        sprintf(String, "%uHz", gSubMenuSelection);
+                        break;
+                case MENU_FOX_FREQ:
+                        sprintf(String, "%3u.%05u", gSubMenuSelection / 100000, gSubMenuSelection % 100000);
+                        break;
+                case MENU_FOX_TONE:
+                        if (gSubMenuSelection == 0)
+                                strcpy(String, "OFF");
+                        else
+                                sprintf(String, "%u.%uHz", gSubMenuSelection / 10, gSubMenuSelection % 10);
                         break;
                 case MENU_FOX_FOUND:
                         strcpy(String, "PLAY");

--- a/ui/menu.h
+++ b/ui/menu.h
@@ -131,6 +131,9 @@ enum
         ,MENU_FOX_INTMAX
         ,MENU_FOX_RANDOM
         ,MENU_FOX_MSG
+        ,MENU_FOX_PITCH
+        ,MENU_FOX_FREQ
+        ,MENU_FOX_TONE
         ,MENU_FOX_FOUND
 #endif
 };


### PR DESCRIPTION
## Summary
- extend FOX config with TX frequency and CTCSS tone
- display frequency and tone while sending Morse code
- add menu entries `FxFreq` and `FxTone`
- persist new values in EEPROM
