### PR TITLE
Introduce FoxHnt main menu with sub menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,11 @@ beacon in the firmware.
 
 ### Accessing the menu
 
-The beacon options now appear in the regular menu near the bottom.  Navigate
-with the `UP`/`DOWN` keys, press `MENU` to edit a value and press `EXIT` to
-cancel.
+Select **FoxHnt** in the main menu and press `MENU` to enter the beacon
+configuration sub menu. Navigate with `UP`/`DOWN`, press `MENU` to edit a value
+and `EXIT` to go back.
 
-### Menu items and keys
+### FoxHnt sub menu items
 
 * **FoxTx** – enable/disable the beacon.
 * **FoxWPM** – CW speed in words per minute (5–40).

--- a/app/menu.c
+++ b/app/menu.c
@@ -1306,11 +1306,15 @@ static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 
 				Value = (gInputBox[0] * 10) + gInputBox[1];
 
-				if (Value > 0 && Value <= gMenuListCount) {
-					gMenuCursor         = Value - 1;
-					gFlagRefreshSetting = true;
-					return;
-				}
+                                if (Value > 0 && Value <= gMenuListCount) {
+                                        gMenuCursor = Value - 1;
+#ifdef ENABLE_FOXHUNT_TX
+                                        if (!gInFoxMenu && gMenuCursor >= gFoxMenuFirstIndex && gMenuCursor <= gFoxMenuLastIndex)
+                                                break;
+#endif
+                                        gFlagRefreshSetting = true;
+                                        return;
+                                }
 
 				if (Value <= gMenuListCount)
 					break;
@@ -1320,11 +1324,15 @@ static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 				[[fallthrough]];
 			case 1:
 				Value = gInputBox[0];
-				if (Value > 0 && Value <= gMenuListCount) {
-					gMenuCursor         = Value - 1;
-					gFlagRefreshSetting = true;
-					return;
-				}
+                                if (Value > 0 && Value <= gMenuListCount) {
+                                        gMenuCursor = Value - 1;
+#ifdef ENABLE_FOXHUNT_TX
+                                        if (!gInFoxMenu && gMenuCursor >= gFoxMenuFirstIndex && gMenuCursor <= gFoxMenuLastIndex)
+                                                break;
+#endif
+                                        gFlagRefreshSetting = true;
+                                        return;
+                                }
 				break;
 		}
 
@@ -1429,8 +1437,8 @@ static void MENU_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
 		   just in case we are exiting from one of them. */
 		BACKLIGHT_TurnOn();
 
-		if (gIsInSubMenu)
-		{
+                if (gIsInSubMenu)
+                {
 			if (gInputBoxIndex == 0 || UI_MENU_GetCurrentMenuId() != MENU_OFFSET)
 			{
 				gAskForConfirmation = 0;
@@ -1484,8 +1492,33 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
 	gBeepToPlay           = BEEP_1KHZ_60MS_OPTIONAL;
 	gRequestDisplayScreen = DISPLAY_MENU;
 
-	if (!gIsInSubMenu)
-	{
+        if (!gIsInSubMenu)
+        {
+#ifdef ENABLE_FOXHUNT_TX
+                if (UI_MENU_GetCurrentMenuId() == MENU_FOX_MENU && !gInFoxMenu) {
+                        gInFoxMenu = true;
+                        gMenuCursor = gFoxMenuFirstIndex;
+                        gFlagRefreshSetting = true;
+                        return;
+                } else if (gInFoxMenu) {
+                        gInFoxMenu = false;
+                        gMenuCursor = gFoxMenuRootIndex;
+                        gFlagRefreshSetting = true;
+                        gRequestDisplayScreen = DISPLAY_MENU;
+                        return;
+                }
+
+#ifdef ENABLE_FOXHUNT_TX
+                if (gInFoxMenu)
+                {
+                        gInFoxMenu = false;
+                        gMenuCursor = gFoxMenuRootIndex;
+                        gFlagRefreshSetting = true;
+                        gRequestDisplayScreen = DISPLAY_MENU;
+                        return;
+                }
+#endif
+#endif
 		#ifdef ENABLE_VOICE
 			if (UI_MENU_GetCurrentMenuId() != MENU_SCR)
 				gAnotherVoiceID = MenuList[gMenuCursor].voice_id;

--- a/main.c
+++ b/main.c
@@ -126,13 +126,19 @@ void Main(void)
 	}
 
 	// count the number of menu items
-	gMenuListCount = 0;
-	while (MenuList[gMenuListCount].name[0] != '\0') {
-		if(!gF_LOCK && MenuList[gMenuListCount].menu_id == FIRST_HIDDEN_MENU_ITEM)
-			break;
+        gMenuListCount = 0;
+        while (MenuList[gMenuListCount].name[0] != '\0') {
+                if(!gF_LOCK && MenuList[gMenuListCount].menu_id == FIRST_HIDDEN_MENU_ITEM)
+                        break;
 
-		gMenuListCount++;
-	}
+                gMenuListCount++;
+        }
+
+#ifdef ENABLE_FOXHUNT_TX
+        gFoxMenuRootIndex  = UI_MENU_GetMenuIdx(MENU_FOX_MENU);
+        gFoxMenuFirstIndex = UI_MENU_GetMenuIdx(MENU_FOX_EN);
+        gFoxMenuLastIndex  = UI_MENU_GetMenuIdx(MENU_FOX_FOUND);
+#endif
 
 	// wait for user to release all butts before moving on
 	if (!GPIO_CheckBit(&GPIOC->DATA, GPIOC_PIN_PTT) ||

--- a/misc.c
+++ b/misc.c
@@ -215,6 +215,12 @@ bool              gKeyBeingHeld;
 bool              gPttIsPressed;
 uint8_t           gPttDebounceCounter;
 uint8_t           gMenuListCount;
+#ifdef ENABLE_FOXHUNT_TX
+bool              gInFoxMenu = false;
+uint8_t           gFoxMenuRootIndex = 0;
+uint8_t           gFoxMenuFirstIndex = 0;
+uint8_t           gFoxMenuLastIndex = 0;
+#endif
 uint8_t           gBackup_CROSS_BAND_RX_TX;
 uint8_t           gScanDelay_10ms;
 uint8_t           gFSKWriteIndex;

--- a/misc.h
+++ b/misc.h
@@ -295,6 +295,12 @@ extern bool                  gKeyBeingHeld;
 extern bool                  gPttIsPressed;
 extern uint8_t               gPttDebounceCounter;
 extern uint8_t               gMenuListCount;
+#ifdef ENABLE_FOXHUNT_TX
+extern bool                  gInFoxMenu;
+extern uint8_t               gFoxMenuRootIndex;
+extern uint8_t               gFoxMenuFirstIndex;
+extern uint8_t               gFoxMenuLastIndex;
+#endif
 extern uint8_t               gBackup_CROSS_BAND_RX_TX;
 extern uint8_t               gScanDelay_10ms;
 extern uint8_t               gFSKWriteIndex;

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -124,6 +124,7 @@ const t_menu_item MenuList[] =
 	{"RxMode", VOICE_ID_DUAL_STANDBY,                  MENU_TDR           },
         {"Sql",    VOICE_ID_SQUELCH,                       MENU_SQL           },
 #ifdef ENABLE_FOXHUNT_TX
+        {"FoxHnt", VOICE_ID_INVALID,                       MENU_FOX_MENU      },
         {"FoxTx",  VOICE_ID_INVALID,                       MENU_FOX_EN        },
         {"FoxWPM", VOICE_ID_INVALID,                       MENU_FOX_WPM       },
         {"IntMin", VOICE_ID_INVALID,                       MENU_FOX_INTMIN    },

--- a/ui/menu.h
+++ b/ui/menu.h
@@ -125,6 +125,7 @@ enum
         MENU_MLONG,
         MENU_BATTYP
 #ifdef ENABLE_FOXHUNT_TX
+        ,MENU_FOX_MENU
         ,MENU_FOX_EN
         ,MENU_FOX_WPM
         ,MENU_FOX_INTMIN


### PR DESCRIPTION
## Summary
- group fox hunt beacon settings under a new `FoxHnt` main menu item
- add support variables for entering/exiting the FoxHnt sub menu
- update menu navigation logic to handle the new sub menu
- document how to access the FoxHnt menu

## Testing
- `make -n`
- `make` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6fa86c048321b1794c48920d14e4