### PR TITLE
Add configurable TX lead/tail delay for FoxHunt

### DIFF
--- a/app/fox.c
+++ b/app/fox.c
@@ -78,6 +78,9 @@ static void send_morse(const char *msg, uint8_t wpm)
     }
     ST7565_BlitFullScreen();
 
+    if (gEeprom.FOX.tx_lead_time)
+        SYSTEM_DelayMs((uint32_t)gEeprom.FOX.tx_lead_time * 1000);
+
     bool aborted = false;
     for (const char *p = msg; *p && idx < sizeof(displayed) - 1 && !aborted; p++) {
         if (check_exit_request()) {
@@ -113,6 +116,9 @@ static void send_morse(const char *msg, uint8_t wpm)
         }
         SYSTEM_DelayMs(unit * 3);
     }
+
+    if (gEeprom.FOX.tx_tail_time)
+        SYSTEM_DelayMs((uint32_t)gEeprom.FOX.tx_tail_time * 1000);
 
     APP_EndTransmission();
     FUNCTION_Select(FUNCTION_FOREGROUND);

--- a/app/menu.c
+++ b/app/menu.c
@@ -386,6 +386,11 @@ int MENU_GetLimits(uint8_t menu_id, int32_t *pMin, int32_t *pMax)
                         *pMin = 0;
                         *pMax = 2541;
                         break;
+                case MENU_FOX_TX_LEAD:
+                case MENU_FOX_TX_TAIL:
+                        *pMin = 0;
+                        *pMax = 60;
+                        break;
 #endif
 
 		case MENU_F1SHRT:
@@ -843,6 +848,12 @@ void MENU_AcceptSetting(void)
                 case MENU_FOX_TONE:
                         gEeprom.FOX.ctcss_hz = gSubMenuSelection;
                         break;
+                case MENU_FOX_TX_LEAD:
+                        gEeprom.FOX.tx_lead_time = gSubMenuSelection;
+                        break;
+                case MENU_FOX_TX_TAIL:
+                        gEeprom.FOX.tx_tail_time = gSubMenuSelection;
+                        break;
                 case MENU_FOX_FOUND:
                         FOX_StartFound();
                         break;
@@ -1230,6 +1241,12 @@ void MENU_ShowCurrentSetting(void)
                         break;
                 case MENU_FOX_TONE:
                         gSubMenuSelection = gEeprom.FOX.ctcss_hz;
+                        break;
+                case MENU_FOX_TX_LEAD:
+                        gSubMenuSelection = gEeprom.FOX.tx_lead_time;
+                        break;
+                case MENU_FOX_TX_TAIL:
+                        gSubMenuSelection = gEeprom.FOX.tx_tail_time;
                         break;
 #endif
 

--- a/settings.c
+++ b/settings.c
@@ -290,6 +290,8 @@ void SETTINGS_InitEEPROM(void)
                         uint32_t frequency;
                         uint16_t pitch_hz;
                         uint16_t ctcss_hz;
+                        uint16_t tx_lead_time;
+                        uint16_t tx_tail_time;
                         char     message[24];
                 } __attribute__((packed)) foxCfg;
                 EEPROM_ReadBuffer(0x1FD0, &foxCfg, sizeof(foxCfg));
@@ -302,6 +304,8 @@ void SETTINGS_InitEEPROM(void)
                 if (gEeprom.FOX.message[0] == '\0') strcpy(gEeprom.FOX.message, "FOX");
                 if (gEeprom.FOX.pitch_hz == 0) gEeprom.FOX.pitch_hz = 800;
                 if (gEeprom.FOX.ctcss_hz > 2541) gEeprom.FOX.ctcss_hz = 0;
+                if (gEeprom.FOX.tx_lead_time > 60) gEeprom.FOX.tx_lead_time = 0;
+                if (gEeprom.FOX.tx_tail_time > 60) gEeprom.FOX.tx_tail_time = 0;
         }
 #endif
 }
@@ -632,6 +636,8 @@ void SETTINGS_SaveSettings(void)
                         uint32_t frequency;
                         uint16_t pitch_hz;
                         uint16_t ctcss_hz;
+                        uint16_t tx_lead_time;
+                        uint16_t tx_tail_time;
                         char     message[24];
                 } __attribute__((packed)) foxCfg;
                 memcpy(&foxCfg, &gEeprom.FOX, sizeof(foxCfg));

--- a/settings.h
+++ b/settings.h
@@ -263,6 +263,8 @@ typedef struct {
                 uint32_t frequency;
                 uint16_t pitch_hz;
                 uint16_t ctcss_hz;
+                uint16_t tx_lead_time;
+                uint16_t tx_tail_time;
                 char     message[24];
         } FOX;
 #endif

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -134,6 +134,8 @@ const t_menu_item MenuList[] =
         {"FxPtch", VOICE_ID_INVALID,                       MENU_FOX_PITCH     },
         {"FxFreq", VOICE_ID_INVALID,                       MENU_FOX_FREQ      },
         {"FxTone", VOICE_ID_INVALID,                       MENU_FOX_TONE      },
+        {"TxLead", VOICE_ID_INVALID,                       MENU_FOX_TX_LEAD   },
+        {"TxTail", VOICE_ID_INVALID,                       MENU_FOX_TX_TAIL   },
         {"FoxFnd", VOICE_ID_INVALID,                       MENU_FOX_FOUND     },
 #endif
 
@@ -877,6 +879,10 @@ void UI_DisplayMenu(void)
                                 strcpy(String, "OFF");
                         else
                                 sprintf(String, "%u.%uHz", gSubMenuSelection / 10, gSubMenuSelection % 10);
+                        break;
+                case MENU_FOX_TX_LEAD:
+                case MENU_FOX_TX_TAIL:
+                        sprintf(String, "%us", gSubMenuSelection);
                         break;
                 case MENU_FOX_FOUND:
                         strcpy(String, "PLAY");

--- a/ui/menu.h
+++ b/ui/menu.h
@@ -135,6 +135,8 @@ enum
         ,MENU_FOX_PITCH
         ,MENU_FOX_FREQ
         ,MENU_FOX_TONE
+        ,MENU_FOX_TX_LEAD
+        ,MENU_FOX_TX_TAIL
         ,MENU_FOX_FOUND
 #endif
 };


### PR DESCRIPTION
## Summary
- allow user configuration of TX lead and tail delays for FoxHunt beacon
- display new FoxHunt options in menu
- persist lead/tail settings in EEPROM
- delay CW transmission accordingly

## Testing
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684c81ea10e08321a93d28b1184f52e4