### PR TITLE
Add foxhunt menu defaults and constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,11 @@ beacon in the firmware.
 
 ### Accessing the menu
 
-Select **FoxHnt** in the main menu and press `MENU` to enter the beacon
+Select **FoxHunt** in the main menu and press `MENU` to enter the beacon
 configuration sub menu. Navigate with `UP`/`DOWN`, press `MENU` to edit a value
 and `EXIT` to go back.
 
-### FoxHnt sub menu items
+### FoxHunt sub menu items
 
 * **FoxTx** – enable/disable the beacon.
 * **FoxWPM** – CW speed in words per minute (5–40).
@@ -239,7 +239,7 @@ and `EXIT` to go back.
   hyphen and `F` for a space.  Press `MENU` again when done.
 * **FxPtch** – CW pitch in hertz (300–1500).
 * **FxFreq** – transmit frequency.
-* **FxTone** – optional CTCSS tone (0 = off).
+* **FoxCTCSS** – optional CTCSS tone (0 = off).
 * **FoxFnd** – send “FOX FOUND” once immediately.
   Pressing the `F` key while the beacon is active does the same and disables the beacon.
 

--- a/app/fox.c
+++ b/app/fox.c
@@ -131,9 +131,9 @@ void FOX_Init(void)
     gFoxCountdown_500ms = 0;
     gFoxFoundMode = false;
     if (gEeprom.FOX.pitch_hz == 0)
-        gEeprom.FOX.pitch_hz = 800;
+        gEeprom.FOX.pitch_hz = 600;
     if (gEeprom.FOX.frequency == 0)
-        gEeprom.FOX.frequency = gRxVfo->pTX->Frequency;
+        gEeprom.FOX.frequency = 14652000;
 }
 
 void FOX_TimeSlice500ms(void)

--- a/app/menu.c
+++ b/app/menu.c
@@ -384,7 +384,7 @@ int MENU_GetLimits(uint8_t menu_id, int32_t *pMin, int32_t *pMax)
                         break;
                 case MENU_FOX_TONE:
                         *pMin = 0;
-                        *pMax = 2541;
+                        *pMax = ARRAY_SIZE(CTCSS_Options);
                         break;
                 case MENU_FOX_TX_LEAD:
                 case MENU_FOX_TX_TAIL:
@@ -846,7 +846,7 @@ void MENU_AcceptSetting(void)
                         gEeprom.FOX.frequency = gSubMenuSelection;
                         break;
                 case MENU_FOX_TONE:
-                        gEeprom.FOX.ctcss_hz = gSubMenuSelection;
+                        gEeprom.FOX.ctcss_hz = (gSubMenuSelection == 0) ? 0 : CTCSS_Options[gSubMenuSelection - 1];
                         break;
                 case MENU_FOX_TX_LEAD:
                         gEeprom.FOX.tx_lead_time = gSubMenuSelection;
@@ -1240,7 +1240,17 @@ void MENU_ShowCurrentSetting(void)
                         gSubMenuSelection = gEeprom.FOX.frequency;
                         break;
                 case MENU_FOX_TONE:
-                        gSubMenuSelection = gEeprom.FOX.ctcss_hz;
+                        if (gEeprom.FOX.ctcss_hz == 0) {
+                                gSubMenuSelection = 0;
+                        } else {
+                                gSubMenuSelection = 0;
+                                for (unsigned int i = 0; i < ARRAY_SIZE(CTCSS_Options); i++) {
+                                        if (CTCSS_Options[i] == gEeprom.FOX.ctcss_hz) {
+                                                gSubMenuSelection = i + 1;
+                                                break;
+                                        }
+                                }
+                        }
                         break;
                 case MENU_FOX_TX_LEAD:
                         gSubMenuSelection = gEeprom.FOX.tx_lead_time;

--- a/app/menu.c
+++ b/app/menu.c
@@ -379,8 +379,8 @@ int MENU_GetLimits(uint8_t menu_id, int32_t *pMin, int32_t *pMax)
                         *pMax = 1500;
                         break;
                 case MENU_FOX_FREQ:
-                        *pMin = frequencyBandTable[0].lower;
-                        *pMax = frequencyBandTable[BAND_N_ELEM - 1].upper;
+                        *pMin = frequencyBandTable[BAND3_137MHz].lower;
+                        *pMax = frequencyBandTable[BAND6_400MHz].upper;
                         break;
                 case MENU_FOX_TONE:
                         *pMin = 0;
@@ -1796,10 +1796,13 @@ static void MENU_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
         }
         if (UI_MENU_GetCurrentMenuId() == MENU_FOX_FREQ) {
                 int32_t freq = (Direction * (int32_t)gTxVfo->StepFrequency) + gSubMenuSelection;
-                if (freq < (int32_t)frequencyBandTable[0].lower)
-                        freq = frequencyBandTable[0].lower;
-                else if (freq > (int32_t)frequencyBandTable[BAND_N_ELEM - 1].upper)
-                        freq = frequencyBandTable[BAND_N_ELEM - 1].upper;
+                if (freq < (int32_t)frequencyBandTable[BAND3_137MHz].lower)
+                        freq = frequencyBandTable[BAND3_137MHz].lower;
+                else if (freq >= (int32_t)frequencyBandTable[BAND3_137MHz].upper &&
+                         freq < (int32_t)frequencyBandTable[BAND6_400MHz].lower)
+                        freq = frequencyBandTable[BAND6_400MHz].lower;
+                else if (freq > (int32_t)frequencyBandTable[BAND6_400MHz].upper)
+                        freq = frequencyBandTable[BAND6_400MHz].upper;
                 gSubMenuSelection     = FREQUENCY_RoundToStep(freq, gTxVfo->StepFrequency);
                 gRequestDisplayScreen = DISPLAY_MENU;
                 return;

--- a/settings.c
+++ b/settings.c
@@ -296,13 +296,13 @@ void SETTINGS_InitEEPROM(void)
                 } __attribute__((packed)) foxCfg;
                 EEPROM_ReadBuffer(0x1FD0, &foxCfg, sizeof(foxCfg));
                 memcpy(&gEeprom.FOX, &foxCfg, sizeof(foxCfg));
-                if (gEeprom.FOX.wpm == 0) gEeprom.FOX.wpm = 10;
-                if (gEeprom.FOX.interval_min == 0) gEeprom.FOX.interval_min = 60;
+                if (gEeprom.FOX.wpm == 0) gEeprom.FOX.wpm = 5;
+                if (gEeprom.FOX.interval_min == 0) gEeprom.FOX.interval_min = 30;
                 if (gEeprom.FOX.interval_max < gEeprom.FOX.interval_min) gEeprom.FOX.interval_max = gEeprom.FOX.interval_min;
-                if (gEeprom.FOX.frequency == 0) gEeprom.FOX.frequency = SETTINGS_FetchChannelFrequency(0);
+                if (gEeprom.FOX.frequency == 0) gEeprom.FOX.frequency = 14652000;
                 if (gEeprom.FOX.power > 2) gEeprom.FOX.power = 1;
                 if (gEeprom.FOX.message[0] == '\0') strcpy(gEeprom.FOX.message, "FOX");
-                if (gEeprom.FOX.pitch_hz == 0) gEeprom.FOX.pitch_hz = 800;
+                if (gEeprom.FOX.pitch_hz == 0) gEeprom.FOX.pitch_hz = 600;
                 if (gEeprom.FOX.ctcss_hz > 2541) gEeprom.FOX.ctcss_hz = 0;
                 if (gEeprom.FOX.tx_lead_time > 60) gEeprom.FOX.tx_lead_time = 0;
                 if (gEeprom.FOX.tx_tail_time > 60) gEeprom.FOX.tx_tail_time = 0;

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -124,7 +124,7 @@ const t_menu_item MenuList[] =
 	{"RxMode", VOICE_ID_DUAL_STANDBY,                  MENU_TDR           },
         {"Sql",    VOICE_ID_SQUELCH,                       MENU_SQL           },
 #ifdef ENABLE_FOXHUNT_TX
-        {"FoxHnt", VOICE_ID_INVALID,                       MENU_FOX_MENU      },
+        {"FoxHunt",VOICE_ID_INVALID,                       MENU_FOX_MENU      },
         {"FoxTx",  VOICE_ID_INVALID,                       MENU_FOX_EN        },
         {"FoxWPM", VOICE_ID_INVALID,                       MENU_FOX_WPM       },
         {"IntMin", VOICE_ID_INVALID,                       MENU_FOX_INTMIN    },
@@ -133,7 +133,7 @@ const t_menu_item MenuList[] =
         {"FoxMsg", VOICE_ID_INVALID,                       MENU_FOX_MSG       },
         {"FxPtch", VOICE_ID_INVALID,                       MENU_FOX_PITCH     },
         {"FxFreq", VOICE_ID_INVALID,                       MENU_FOX_FREQ      },
-        {"FoxCcs", VOICE_ID_INVALID,                       MENU_FOX_TONE      },
+        {"FoxCTCSS",VOICE_ID_INVALID,                      MENU_FOX_TONE      },
         {"TxLead", VOICE_ID_INVALID,                       MENU_FOX_TX_LEAD   },
         {"TxTail", VOICE_ID_INVALID,                       MENU_FOX_TX_TAIL   },
         {"FoxFnd", VOICE_ID_INVALID,                       MENU_FOX_FOUND     },
@@ -878,7 +878,8 @@ void UI_DisplayMenu(void)
                         if (gSubMenuSelection == 0)
                                 strcpy(String, "OFF");
                         else
-                                sprintf(String, "%u.%uHz", gSubMenuSelection / 10, gSubMenuSelection % 10);
+                                sprintf(String, "%u.%uHz", CTCSS_Options[gSubMenuSelection - 1] / 10,
+                                        CTCSS_Options[gSubMenuSelection - 1] % 10);
                         break;
                 case MENU_FOX_TX_LEAD:
                 case MENU_FOX_TX_TAIL:

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -133,7 +133,7 @@ const t_menu_item MenuList[] =
         {"FoxMsg", VOICE_ID_INVALID,                       MENU_FOX_MSG       },
         {"FxPtch", VOICE_ID_INVALID,                       MENU_FOX_PITCH     },
         {"FxFreq", VOICE_ID_INVALID,                       MENU_FOX_FREQ      },
-        {"FxTone", VOICE_ID_INVALID,                       MENU_FOX_TONE      },
+        {"FoxCcs", VOICE_ID_INVALID,                       MENU_FOX_TONE      },
         {"TxLead", VOICE_ID_INVALID,                       MENU_FOX_TX_LEAD   },
         {"TxTail", VOICE_ID_INVALID,                       MENU_FOX_TX_TAIL   },
         {"FoxFnd", VOICE_ID_INVALID,                       MENU_FOX_FOUND     },
@@ -872,7 +872,7 @@ void UI_DisplayMenu(void)
                         sprintf(String, "%uHz", gSubMenuSelection);
                         break;
                 case MENU_FOX_FREQ:
-                        sprintf(String, "%3u.%05u", gSubMenuSelection / 100000, gSubMenuSelection % 100000);
+                        sprintf(String, "%3u.%03u", gSubMenuSelection / 100000, (gSubMenuSelection % 100000) / 100);
                         break;
                 case MENU_FOX_TONE:
                         if (gSubMenuSelection == 0)

--- a/ui/menu.h
+++ b/ui/menu.h
@@ -24,7 +24,7 @@
 #include "settings.h"
 
 typedef struct {
-	const char  name[7];    // menu display area only has room for 6 characters
+        const char  name[9];    // menu display area only has room for 6 characters
 	VOICE_ID_t  voice_id;
 	uint8_t     menu_id;
 } t_menu_item;


### PR DESCRIPTION
## Summary
- tweak FOX defaults for WPM, intervals, frequency and pitch
- update FOX init defaults to match
- rename the foxhunt tone menu entry
- show fox frequency using fewer decimal places
- limit fox frequency edits to VHF/UHF bands

## Testing
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684cc9f1f10c832196d2fcb1e187cc78