### PR TITLE
Fix FoxHunt defaults and frequency entry

### DIFF
--- a/app/menu.c
+++ b/app/menu.c
@@ -1534,17 +1534,6 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
                         gRequestDisplayScreen = DISPLAY_MENU;
                         return;
                 }
-
-#ifdef ENABLE_FOXHUNT_TX
-                if (gInFoxMenu)
-                {
-                        gInFoxMenu = false;
-                        gMenuCursor = gFoxMenuRootIndex;
-                        gFlagRefreshSetting = true;
-                        gRequestDisplayScreen = DISPLAY_MENU;
-                        return;
-                }
-#endif
 #endif
 		#ifdef ENABLE_VOICE
 			if (UI_MENU_GetCurrentMenuId() != MENU_SCR)

--- a/app/menu.c
+++ b/app/menu.c
@@ -1369,8 +1369,8 @@ static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 		return;
 	}
 
-	if (UI_MENU_GetCurrentMenuId() == MENU_OFFSET) {
-		uint32_t Frequency;
+        if (UI_MENU_GetCurrentMenuId() == MENU_OFFSET || UI_MENU_GetCurrentMenuId() == MENU_FOX_FREQ) {
+                uint32_t Frequency;
 
 		if (gInputBoxIndex < 6) { // invalid frequency
 #ifdef ENABLE_VOICE
@@ -1383,8 +1383,8 @@ static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 		gAnotherVoiceID = (VOICE_ID_t)Key;
 #endif
 
-		Frequency = StrToUL(INPUTBOX_GetAscii())*100;
-		gSubMenuSelection = FREQUENCY_RoundToStep(Frequency, gTxVfo->StepFrequency);
+                Frequency = StrToUL(INPUTBOX_GetAscii())*100;
+                gSubMenuSelection = FREQUENCY_RoundToStep(Frequency, gTxVfo->StepFrequency);
 
 		gInputBoxIndex = 0;
 		return;
@@ -1466,7 +1466,7 @@ static void MENU_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
 
                 if (gIsInSubMenu)
                 {
-			if (gInputBoxIndex == 0 || UI_MENU_GetCurrentMenuId() != MENU_OFFSET)
+                        if (gInputBoxIndex == 0 || (UI_MENU_GetCurrentMenuId() != MENU_OFFSET && UI_MENU_GetCurrentMenuId() != MENU_FOX_FREQ))
 			{
 				gAskForConfirmation = 0;
 				gIsInSubMenu        = false;

--- a/app/menu.c
+++ b/app/menu.c
@@ -1773,23 +1773,37 @@ static void MENU_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
 	if (SCANNER_IsScanning())
 		return;
 
-	if (!gIsInSubMenu) {
-		gMenuCursor = NUMBER_AddWithWraparound(gMenuCursor, -Direction, 0, gMenuListCount - 1);
+        if (!gIsInSubMenu) {
+                gMenuCursor = NUMBER_AddWithWraparound(gMenuCursor, -Direction, 0, gMenuListCount - 1);
 
-		gFlagRefreshSetting = true;
+#ifdef ENABLE_FOXHUNT_TX
+                if (!gInFoxMenu && gMenuCursor >= gFoxMenuFirstIndex && gMenuCursor <= gFoxMenuLastIndex) {
+                        if (Direction > 0)
+                                gMenuCursor = gFoxMenuLastIndex + 1;
+                        else
+                                gMenuCursor = gFoxMenuFirstIndex - 1;
+                } else if (gInFoxMenu) {
+                        if (gMenuCursor < gFoxMenuFirstIndex)
+                                gMenuCursor = gFoxMenuLastIndex;
+                        else if (gMenuCursor > gFoxMenuLastIndex)
+                                gMenuCursor = gFoxMenuFirstIndex;
+                }
+#endif
 
-		gRequestDisplayScreen = DISPLAY_MENU;
+                gFlagRefreshSetting = true;
 
-		if (UI_MENU_GetCurrentMenuId() != MENU_ABR
-			&& UI_MENU_GetCurrentMenuId() != MENU_ABR_MIN
-			&& UI_MENU_GetCurrentMenuId() != MENU_ABR_MAX
-			&& gEeprom.BACKLIGHT_TIME == 0) // backlight always off and not in the backlight menu
-		{
-			BACKLIGHT_TurnOff();
-		}
+                gRequestDisplayScreen = DISPLAY_MENU;
 
-		return;
-	}
+                if (UI_MENU_GetCurrentMenuId() != MENU_ABR
+                        && UI_MENU_GetCurrentMenuId() != MENU_ABR_MIN
+                        && UI_MENU_GetCurrentMenuId() != MENU_ABR_MAX
+                        && gEeprom.BACKLIGHT_TIME == 0) // backlight always off and not in the backlight menu
+                {
+                        BACKLIGHT_TurnOff();
+                }
+
+                return;
+        }
 
         if (UI_MENU_GetCurrentMenuId() == MENU_OFFSET) {
                 int32_t Offset = (Direction * gTxVfo->StepFrequency) + gSubMenuSelection;

--- a/settings.c
+++ b/settings.c
@@ -296,22 +296,39 @@ void SETTINGS_InitEEPROM(void)
                 } __attribute__((packed)) foxCfg;
                 EEPROM_ReadBuffer(0x1FD0, &foxCfg, sizeof(foxCfg));
                 memcpy(&gEeprom.FOX, &foxCfg, sizeof(foxCfg));
-                if (gEeprom.FOX.wpm == 0 || gEeprom.FOX.wpm == 0xFF)
+                if (gEeprom.FOX.enabled > 1)
+                        gEeprom.FOX.enabled = 0;
+                if (gEeprom.FOX.random > 1)
+                        gEeprom.FOX.random = 0;
+                if (gEeprom.FOX.wpm < 5 || gEeprom.FOX.wpm > 40)
                         gEeprom.FOX.wpm = 5;
-                if (gEeprom.FOX.interval_min == 0 || gEeprom.FOX.interval_min == 0xFFFF)
+                if (gEeprom.FOX.interval_min < 1 || gEeprom.FOX.interval_min > 600 || gEeprom.FOX.interval_min == 0xFFFF)
                         gEeprom.FOX.interval_min = 30;
-                if (gEeprom.FOX.interval_max == 0xFFFF)
+                if (gEeprom.FOX.interval_max < gEeprom.FOX.interval_min || gEeprom.FOX.interval_max > 600 || gEeprom.FOX.interval_max == 0xFFFF)
                         gEeprom.FOX.interval_max = gEeprom.FOX.interval_min;
-                if (gEeprom.FOX.interval_max < gEeprom.FOX.interval_min)
-                        gEeprom.FOX.interval_max = gEeprom.FOX.interval_min;
-                if (gEeprom.FOX.frequency == 0 || gEeprom.FOX.frequency == 0xFFFFFFFF)
+                if (gEeprom.FOX.frequency < 1000000 || gEeprom.FOX.frequency > 60000000 || gEeprom.FOX.frequency == 0xFFFFFFFF)
                         gEeprom.FOX.frequency = 14652000;
-                if (gEeprom.FOX.power > 2) gEeprom.FOX.power = 1;
-                if (gEeprom.FOX.message[0] == '\0') strcpy(gEeprom.FOX.message, "FOX");
-                if (gEeprom.FOX.pitch_hz == 0) gEeprom.FOX.pitch_hz = 600;
-                if (gEeprom.FOX.ctcss_hz > 2541) gEeprom.FOX.ctcss_hz = 0;
-                if (gEeprom.FOX.tx_lead_time > 60) gEeprom.FOX.tx_lead_time = 0;
-                if (gEeprom.FOX.tx_tail_time > 60) gEeprom.FOX.tx_tail_time = 0;
+                if (gEeprom.FOX.power > 2)
+                        gEeprom.FOX.power = 1;
+                if (gEeprom.FOX.message[0] == '\0')
+                        strcpy(gEeprom.FOX.message, "FOX");
+                if (gEeprom.FOX.pitch_hz < 300 || gEeprom.FOX.pitch_hz > 1500)
+                        gEeprom.FOX.pitch_hz = 600;
+                {
+                        bool ctcss_ok = false;
+                        for (unsigned int i = 0; i < ARRAY_SIZE(CTCSS_Options); i++) {
+                                if (CTCSS_Options[i] == gEeprom.FOX.ctcss_hz) {
+                                        ctcss_ok = true;
+                                        break;
+                                }
+                        }
+                        if (!ctcss_ok)
+                                gEeprom.FOX.ctcss_hz = 0;
+                }
+                if (gEeprom.FOX.tx_lead_time > 60)
+                        gEeprom.FOX.tx_lead_time = 0;
+                if (gEeprom.FOX.tx_tail_time > 60)
+                        gEeprom.FOX.tx_tail_time = 0;
         }
 #endif
 }

--- a/settings.c
+++ b/settings.c
@@ -296,10 +296,16 @@ void SETTINGS_InitEEPROM(void)
                 } __attribute__((packed)) foxCfg;
                 EEPROM_ReadBuffer(0x1FD0, &foxCfg, sizeof(foxCfg));
                 memcpy(&gEeprom.FOX, &foxCfg, sizeof(foxCfg));
-                if (gEeprom.FOX.wpm == 0) gEeprom.FOX.wpm = 5;
-                if (gEeprom.FOX.interval_min == 0) gEeprom.FOX.interval_min = 30;
-                if (gEeprom.FOX.interval_max < gEeprom.FOX.interval_min) gEeprom.FOX.interval_max = gEeprom.FOX.interval_min;
-                if (gEeprom.FOX.frequency == 0) gEeprom.FOX.frequency = 14652000;
+                if (gEeprom.FOX.wpm == 0 || gEeprom.FOX.wpm == 0xFF)
+                        gEeprom.FOX.wpm = 5;
+                if (gEeprom.FOX.interval_min == 0 || gEeprom.FOX.interval_min == 0xFFFF)
+                        gEeprom.FOX.interval_min = 30;
+                if (gEeprom.FOX.interval_max == 0xFFFF)
+                        gEeprom.FOX.interval_max = gEeprom.FOX.interval_min;
+                if (gEeprom.FOX.interval_max < gEeprom.FOX.interval_min)
+                        gEeprom.FOX.interval_max = gEeprom.FOX.interval_min;
+                if (gEeprom.FOX.frequency == 0 || gEeprom.FOX.frequency == 0xFFFFFFFF)
+                        gEeprom.FOX.frequency = 14652000;
                 if (gEeprom.FOX.power > 2) gEeprom.FOX.power = 1;
                 if (gEeprom.FOX.message[0] == '\0') strcpy(gEeprom.FOX.message, "FOX");
                 if (gEeprom.FOX.pitch_hz == 0) gEeprom.FOX.pitch_hz = 600;

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -872,7 +872,16 @@ void UI_DisplayMenu(void)
                         sprintf(String, "%uHz", gSubMenuSelection);
                         break;
                 case MENU_FOX_FREQ:
-                        sprintf(String, "%3u.%03u", gSubMenuSelection / 100000, (gSubMenuSelection % 100000) / 100);
+                        if (!gIsInSubMenu || gInputBoxIndex == 0) {
+                                sprintf(String, "%3u.%03u", gSubMenuSelection / 100000, (gSubMenuSelection % 100000) / 100);
+                                UI_PrintString(String, menu_item_x1, menu_item_x2, 1, 8);
+                        } else {
+                                const char * ascii = INPUTBOX_GetAscii();
+                                sprintf(String, "%.3s.%.3s  ", ascii, ascii + 3);
+                                UI_PrintString(String, menu_item_x1, menu_item_x2, 1, 8);
+                        }
+                        UI_PrintString("MHz",  menu_item_x1, menu_item_x2, 3, 8);
+                        already_printed = true;
                         break;
                 case MENU_FOX_TONE:
                         if (gSubMenuSelection == 0)

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -856,11 +856,17 @@ void UI_DisplayMenu(void)
                         strcpy(String, gSubMenu_OFF_ON[gSubMenuSelection]);
                         break;
                 case MENU_FOX_WPM:
-                        sprintf(String, "%u WPM", gSubMenuSelection);
+                        if (!gIsInSubMenu || gInputBoxIndex == 0)
+                                sprintf(String, "%u WPM", gSubMenuSelection);
+                        else
+                                sprintf(String, "%u WPM", StrToUL(INPUTBOX_GetAscii()));
                         break;
                 case MENU_FOX_INTMIN:
                 case MENU_FOX_INTMAX:
-                        sprintf(String, "%us", gSubMenuSelection);
+                        if (!gIsInSubMenu || gInputBoxIndex == 0)
+                                sprintf(String, "%us", gSubMenuSelection);
+                        else
+                                sprintf(String, "%us", StrToUL(INPUTBOX_GetAscii()));
                         break;
                 case MENU_FOX_MSG:
                         if(edit_index >= 0)
@@ -869,7 +875,10 @@ void UI_DisplayMenu(void)
                                 strcpy(String, gEeprom.FOX.message);
                         break;
                 case MENU_FOX_PITCH:
-                        sprintf(String, "%uHz", gSubMenuSelection);
+                        if (!gIsInSubMenu || gInputBoxIndex == 0)
+                                sprintf(String, "%uHz", gSubMenuSelection);
+                        else
+                                sprintf(String, "%uHz", StrToUL(INPUTBOX_GetAscii()));
                         break;
                 case MENU_FOX_FREQ:
                         if (!gIsInSubMenu || gInputBoxIndex == 0) {
@@ -892,7 +901,10 @@ void UI_DisplayMenu(void)
                         break;
                 case MENU_FOX_TX_LEAD:
                 case MENU_FOX_TX_TAIL:
-                        sprintf(String, "%us", gSubMenuSelection);
+                        if (!gIsInSubMenu || gInputBoxIndex == 0)
+                                sprintf(String, "%us", gSubMenuSelection);
+                        else
+                                sprintf(String, "%us", StrToUL(INPUTBOX_GetAscii()));
                         break;
                 case MENU_FOX_FOUND:
                         strcpy(String, "PLAY");


### PR DESCRIPTION
## Summary
- handle invalid FOXHUNT settings loaded from EEPROM
- allow typing a frequency in the FoxHunt menu
- display typed FoxHunt frequency during entry

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_684cd1cce44c83218b8291333ce234ed