### PR TITLE
Fix fox hunt submenu editing

### DIFF
--- a/app/menu.c
+++ b/app/menu.c
@@ -1486,11 +1486,21 @@ static void MENU_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
 			return;
 		}
 
-		#ifdef ENABLE_VOICE
-			gAnotherVoiceID = VOICE_ID_CANCEL;
-		#endif
+               #ifdef ENABLE_VOICE
+                        gAnotherVoiceID = VOICE_ID_CANCEL;
+               #endif
 
-		gRequestDisplayScreen = DISPLAY_MAIN;
+#ifdef ENABLE_FOXHUNT_TX
+               if (gInFoxMenu) {
+                        gInFoxMenu = false;
+                        gMenuCursor = gFoxMenuRootIndex;
+                        gFlagRefreshSetting = true;
+                        gRequestDisplayScreen = DISPLAY_MENU;
+                        return;
+               }
+#endif
+
+               gRequestDisplayScreen = DISPLAY_MAIN;
 
 		if (gEeprom.BACKLIGHT_TIME == 0) // backlight set to always off
 		{
@@ -1527,7 +1537,7 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
                         gMenuCursor = gFoxMenuFirstIndex;
                         gFlagRefreshSetting = true;
                         return;
-                } else if (gInFoxMenu) {
+                } else if (gInFoxMenu && UI_MENU_GetCurrentMenuId() == MENU_FOX_MENU) {
                         gInFoxMenu = false;
                         gMenuCursor = gFoxMenuRootIndex;
                         gFlagRefreshSetting = true;


### PR DESCRIPTION
## Summary
- ensure MENU key exits fox submenu only from root item
- allow EXIT key to back out of foxhunt submenu

## Testing
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684cde88b6588321b867d8181ce2af4b