### PR TITLE
Improve FoxHunt tone selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ and `EXIT` to go back.
 * **FxPtch** – CW pitch in hertz (300–1500).
 * **FxFreq** – transmit frequency.
 * **FoxCTCSS** – optional CTCSS tone (0 = off).
+  Use `UP`/`DOWN` to cycle through the standard tones; number keys are ignored.
 * **FoxFnd** – send “FOX FOUND” once immediately.
   Pressing the `F` key while the beacon is active does the same and disables the beacon.
 

--- a/app/menu.c
+++ b/app/menu.c
@@ -1295,8 +1295,11 @@ static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 	int32_t  Max;
 	uint16_t Value = 0;
 
-	if (bKeyHeld || !bKeyPressed)
-		return;
+        if (bKeyHeld || !bKeyPressed)
+                return;
+
+        if (gIsInSubMenu && UI_MENU_GetCurrentMenuId() == MENU_FOX_TONE)
+                return;             // tone selection via UP/DOWN only
 
 	gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 


### PR DESCRIPTION
## Summary
- disable numeric input when editing the FoxHunt CTCSS tone
- clarify README to use UP/DOWN keys for tone selection

## Testing
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_684ce3dc3f8c832195c68fe2becdb71a