### PR TITLE
Fix foxhunt countdown timing

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -57,9 +57,6 @@ void SystickHandler(void)
 		gNextTimeslice_500ms = true;
 		
                 DECREMENT_AND_TRIGGER(gTxTimerCountdown_500ms, gTxTimeoutReached);
-#ifdef ENABLE_FOXHUNT_TX
-                DECREMENT(gFoxCountdown_500ms);
-#endif
                 DECREMENT(gSerialConfigCountDown_500ms);
 	}
 


### PR DESCRIPTION
## Summary
- fix double decrement of foxhunt timer

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_684ce59db15483219f229fe61436c775