### PR TITLE
Improve fox hunt TX controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ and `EXIT` to go back.
 
 ### FoxHunt sub menu items
 
-* **FoxTx** – enable/disable the beacon.
+* **FoxTx** – enable/disable the beacon. A message must be set before it can be enabled; press `EXIT` while active to stop transmission.
 * **FoxWPM** – CW speed in words per minute (5–40).
 * **IntMin** – minimum interval between transmissions (seconds).
 * **IntMax** – maximum interval used when randomising.

--- a/app/main.c
+++ b/app/main.c
@@ -419,8 +419,17 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 
 static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld)
 {
-	if (!bKeyHeld && bKeyPressed) { // exit key pressed
-		gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
+#ifdef ENABLE_FOXHUNT_TX
+        if (!bKeyHeld && bKeyPressed && gEeprom.FOX.enabled) {
+                gEeprom.FOX.enabled = false;
+                gFoxCountdown_500ms = 0;
+                gRequestSaveSettings = true;
+                gUpdateStatus = true;
+                return;
+        }
+#endif
+        if (!bKeyHeld && bKeyPressed) { // exit key pressed
+                gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 
 #ifdef ENABLE_DTMF_CALLING
 		if (gDTMF_CallState != DTMF_CALL_STATE_NONE && gCurrentFunction != FUNCTION_TRANSMIT)

--- a/app/menu.c
+++ b/app/menu.c
@@ -821,6 +821,10 @@ void MENU_AcceptSetting(void)
                         break;
 #ifdef ENABLE_FOXHUNT_TX
                 case MENU_FOX_EN:
+                        if (gSubMenuSelection && gEeprom.FOX.message[0] == '\0') {
+                                gSubMenuSelection = 0;
+                                gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
+                        }
                         gEeprom.FOX.enabled = gSubMenuSelection;
                         break;
                 case MENU_FOX_WPM:


### PR DESCRIPTION
## Summary
- prevent enabling fox hunt TX when no message is set
- allow pressing `EXIT` to disable fox hunt TX
- document the new behaviour in README

## Testing
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684ceb5d04608321950c6fd2a0854e9c