### PR TITLE
Fix foxhunt TX not in FM

### DIFF
--- a/app/fox.c
+++ b/app/fox.c
@@ -55,9 +55,14 @@ static void send_morse(const char *msg, uint8_t wpm)
     uint16_t unit = 1200 / wpm;
 
     FUNCTION_Select(FUNCTION_TRANSMIT);
+    RADIO_SetModulation(MODULATION_FM);
     SYSTEM_DelayMs(20);
 
     BK4819_SetFrequency(gEeprom.FOX.frequency);
+    BK4819_PickRXFilterPathBasedOnFrequency(gEeprom.FOX.frequency);
+    BK4819_SetupPowerAmplifier(gCurrentVfo->TXP_CalculatedSetting, gEeprom.FOX.frequency);
+    BK4819_PrepareTransmit();
+
     if (gEeprom.FOX.ctcss_hz)
         BK4819_SetCTCSSFrequency(gEeprom.FOX.ctcss_hz);
     else


### PR DESCRIPTION
## Summary
- ensure fox beacon sets FM mode when transmitting
- reinitialize TX path after changing frequency

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_684cee56a0b08321be06c24feb652a8c